### PR TITLE
Change default duty cycle to 100%

### DIFF
--- a/buzzerComponent/buzzer.c
+++ b/buzzerComponent/buzzer.c
@@ -40,7 +40,7 @@
 static bool Enabled = false;
 
 // The on percentage of the buzzer on/off duty cycle (0 to 100).
-static double DutyCycleOnPercent = 50;
+static double DutyCycleOnPercent = 100;
 
 // The total number of milliseconds in the full duty cycle period (on + off).
 // Must be >= 10 and <= 3600000 (i.e. 1 hour).


### PR DESCRIPTION
This removes the need to override the duty cycle percent
configuration from the helloYellow app, which was causing
some confusion when using both Octave and helloYellow at
the same time. Settings pushed to the buzzer from Octave
were being overridden by the helloYellow app, and it
wasn't obvious why the values were arriving modified at
the buzzer app.